### PR TITLE
Fix  cicid for c ports

### DIFF
--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -8,8 +8,7 @@ env:
   PYTHON_VERSION: "3.10"
 
 jobs:
-
-  # build wheel and prepare tarball with sources. since sources are OS-agnostic 
+  # build wheel and prepare tarball with sources. since sources are OS-agnostic
   # it's ok to owerwrite sdists prepared by each of OS
   # currently we don't support windows
   Build-Multiplatform-Package:
@@ -31,6 +30,8 @@ jobs:
           pip install -r requirements/develop.txt
       - name: Build Wheel Package
         run: python setup.py sdist bdist_wheel
+      - name: Checki if package can be uploaded to PyPI
+        run: python -m twine check dist/*
       - name: Save artifacts
         uses: actions/upload-artifact@master
         with:

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -2,47 +2,91 @@ name: package builds
 
 on:
   push:
-    branches: [master]
+    branches: [fix--cicid-for-c-ports]
+
+env:
+  PYTHON_VERSION: "3.10"
 
 jobs:
-  Build-Package:
-    runs-on: ubuntu-latest
+
+  # build wheel and prepare tarball with sources. since sources are OS-agnostic 
+  # it's ok to owerwrite sdists prepared by each of OS
+  # currently we don't support windows
+  Build-Multiplatform-Package:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements/production.txt
           pip install -r requirements/develop.txt
-      - name: Build for PyPI
+      - name: Build Wheel Package
         run: python setup.py sdist bdist_wheel
       - name: Save artifacts
         uses: actions/upload-artifact@master
         with:
-          name: build
+          name: dist_temp
           path: ./dist
+
+  # previous job used Ubuntu OS, but PyPI requires ManyLinux distro, hence we
+  # need to convert it properly
+  Convert-Ubuntu-To-Manylinux:
+    runs-on: ubuntu-latest
+    needs: [Build-Multiplatform-Package]
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip auditwheel
+      - name: Download artifacts
+        uses: actions/download-artifact@master
+        with:
+          name: dist_temp
+          path: ./dist
+      - name: Convert Ubuntu to ManyLinux
+        run: |
+          auditwheel show dist/network_diffusion-*-linux_x86_64.whl
+          auditwheel repair --wheel-dir dist dist/network_diffusion-*-linux_x86_64.whl
+      - name: Remove Ubuntu based build
+        run: rm dist/network_diffusion-*-linux_x86_64.whl
+      - name: Save artifacts
+        uses: actions/upload-artifact@master
+        with:
+          name: dist_final
+          path: ./dist
+
+  # download builds and send them to Python Package Index
   Publish-Package:
     runs-on: ubuntu-latest
-    needs: [Build-Package]
+    needs: [Convert-Ubuntu-To-Manylinux]
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@master
         with:
-          name: build
+          name: dist_final
           path: ./dist
       - name: Publishing to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
+
+  # create a GitHub release and tag current commit
   Create-Tag-Release:
     runs-on: ubuntu-latest
-    needs: [Build-Package]
+    needs: [Convert-Ubuntu-To-Manylinux]
     env:
       VER: Nil
     steps:
@@ -60,7 +104,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@master
         with:
-          name: build
+          name: dist_final
           path: ./dist
       - name: Add GitHub release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -2,7 +2,7 @@ name: package builds
 
 on:
   push:
-    branches: [fix--cicid-for-c-ports]
+    branches: [master]
 
 env:
   PYTHON_VERSION: "3.10"

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -2,7 +2,7 @@ name: package builds
 
 on:
   push:
-    branches: [master]
+    branches: [fix--cicid-for-c-ports]
 
 env:
   PYTHON_VERSION: "3.10"
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include LICENSE
+include requirements/production.txt
+recursive-include c_modules *.*
+prune */__pycache__
+global-exclude *.o *.so *.dylib *.a .git *.pyc

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ including temporal models, multilayer models, and combinations of both.
 ## Installation
 
 **To install package run this command: `pip install network_diffusion`**.
-Please note, that currently we support Linux and MacOS only.
+Please note, that currently we support Linux, MacOS, and Windows only.
 
 If you like the package, please cite us as:
 

--- a/README.md
+++ b/README.md
@@ -43,5 +43,5 @@ Please cite as:
 ## New features incoming!
 
 Current board with issues and state of the progress torwards implementing new
-functionalities is here:
-https://github.com/users/anty-filidor/projects/6/views/1
+functionalities is
+[here](https://github.com/users/anty-filidor/projects/6/views/1).gi

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This Python library provides a versatile toolkit for simulating diffusion
 processes in complex networks. It offers support for various types of models,
 including temporal models, multilayer models, and combinations of both.
 
-<center> <b>Documentation</b> is available <a href="https://network-diffusion.readthedocs.io/en/latest/">here</a>! </center>
+<p align="center"> <b>Documentation</b> is available <a href="https://network-diffusion.readthedocs.io/en/latest/">here</a>! </p>
 
 ## Key Features
 
@@ -78,11 +78,11 @@ If you like the package, please cite us as:
 
 A board with issues and state of the progress torwards implementing new
 functionalities can be found
-[here](https://github.com/users/anty-filidor/projects/6/views/1)
+[here](https://github.com/users/anty-filidor/projects/6/views/1).
 
 ## About us
 
 This library is developed and maintained by Network Science Lab at
 [WUST](https://networks.pwr.edu.pl/) and external partners. For more
-information and updates, please visit our website:
-[https://networks.pwr.edu.pl/](https://networks.pwr.edu.pl/).
+information and updates, please visit our :
+[website](https://networks.pwr.edu.pl/).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Network Diffusion - spreading models in multilayer networks
+# Network Diffusion - spreading models in complex networks
 
 [![License: GPL](https://img.shields.io/github/license/anty-filidor/network_diffusion)](https://www.gnu.org/licenses/gpl-3.0.html)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4592269.svg)](https://doi.org/10.5281/zenodo.4592269)
@@ -11,16 +11,52 @@
 [![codecov](https://codecov.io/gh/anty-filidor/network_diffusion/branch/package-simplification/graph/badge.svg?token=LF52GAD73F)](https://codecov.io/gh/anty-filidor/network_diffusion)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fanty-filidor%2Fnetwork_diffusion.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fanty-filidor%2Fnetwork_diffusion?ref=badge_shield)
 
-Network Diffusion is a library that allows to design and run diffusion
-phenomena processes in networks. The package has been built based on
-[NetworkX](https://networkx.github.io) and is fully compatible. With Network
-Diffusion, the user can work with multi- and single-layer networks, define
-propagation models from scratch, use predefined ones, and perform simulations.
+This Python library provides a versatile toolkit for simulating diffusion
+processes in complex networks. It offers support for various types of models,
+including temporal models, multilayer models, and combinations of both.
 
-Documentation and tutorials are available
-[here](https://network-diffusion.readthedocs.io/en/latest/).
+<center> <b>Documentation</b> is available <a href="https://network-diffusion.readthedocs.io/en/latest/">here</a>! </center>
 
-Please cite as:
+## Key Features
+
+- **Complex Network Simulation**: The library enables users to simulate
+  diffusion processes in complex networks with ease. Whether you are studying
+  information spread, disease propagation, or any other diffusion phenomena,
+  this library has you covered.
+
+- **Temporal Models**: You can work with temporal models, allowing you to
+  capture the dynamics of processes over time. These temporal models can be
+  created using regular time windows or leverage
+  [CogSnet](https://www.researchgate.net/publication/348341904_Social_Networks_through_the_Prism_of_Cognition).
+
+- **Multilayer Networks**: The library supports multilayer networks, which are
+  essential for modeling real-world systems with interconnected layers of
+  complexity.
+
+- **Predefined Models**: You have the option to use predefined diffusion models
+  such as the Linear Threshold Model, Independent Cascade Model, and more.
+  These models simplify the simulation process, allowing you to focus on your
+  specific research questions.
+
+- **Custom Models**: Additionally, Nwtwork Diffusion allows you to define your
+  own diffusion models using open interfaces, providing flexibility for
+  researchers to tailor simulations to their unique requirements.
+
+- **Centrality Measures**: The library provides a wide range of centrality
+  measures specifically designed for multilayer networks. These measures can be
+  valuable for selecting influential seed nodes in diffusion processes.
+
+- **NetworkX Compatibility**: Last but not least, the package is built on top
+  of NetworkX, ensuring seamless compatibility with this popular Python library
+  for network analysis. You can easily integrate it into your existing
+  NetworkX-based workflows.
+
+## Installation
+
+**To install package run this command: `pip install network_diffusion`**.
+Please note, that currently we support Linux and MacOS only.
+
+If you like the package, please cite us as:
 
 ```
 @INPROCEEDINGS{czuba2022networkdiffusion,
@@ -38,10 +74,15 @@ Please cite as:
 }
 ```
 
-**To install package run this command: `pip install network_diffusion`**
+## New features incoming
 
-## New features incoming!
+A board with issues and state of the progress torwards implementing new
+functionalities can be found
+[here](https://github.com/users/anty-filidor/projects/6/views/1)
 
-Current board with issues and state of the progress torwards implementing new
-functionalities is
-[here](https://github.com/users/anty-filidor/projects/6/views/1).gi
+## About us
+
+This library is developed and maintained by Network Science Lab at
+[WUST](https://networks.pwr.edu.pl/) and external partners. For more
+information and updates, please visit our website:
+[https://networks.pwr.edu.pl/](https://networks.pwr.edu.pl/).

--- a/c_modules/cogsnet_compute.c
+++ b/c_modules/cogsnet_compute.c
@@ -17,7 +17,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <unistd.h>
+#include <unistd.h>  // TODO (MN): this is Unix-specific library!
 
 // linear forgetting
 float compute_weight_linear(int new_event, float weight_last_event,

--- a/c_modules/cogsnet_compute.c
+++ b/c_modules/cogsnet_compute.c
@@ -17,7 +17,13 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <unistd.h>  // TODO (MN): this is Unix-specific library!
+#ifdef _WIN32
+// Windows-specific code
+#include <windows.h>
+#else
+// Unix-like system code
+#include <unistd.h>
+#endif
 
 // linear forgetting
 float compute_weight_linear(int new_event, float weight_last_event,
@@ -388,12 +394,23 @@ struct Cogsnet cogsnet(const char *forgetting_type, int snapshot_interval,
     return network;
   }
 
+#ifdef _WIN32
+  // Windows-specific code
+  if (GetFileAttributes(path_events) == INVALID_FILE_ATTRIBUTES) {
+    network.exit_status = 1;
+    snprintf(network.error_msg, sizeof(network.error_msg),
+             "[ERROR] File does not exist: %s.\n", path_events);
+    return network;
+  }
+#else
+  // Unix-like system code
   if (access(path_events, F_OK) != 0) {
     network.exit_status = 1;
     snprintf(network.error_msg, sizeof(network.error_msg),
              "[ERROR] File does not exist: %s.\n", path_events);
     return network;
   }
+#endif
 
   if (!(strcmp(delimiter, ",") == 0 || strcmp(delimiter, ";") == 0 ||
         strcmp(delimiter, "\t") == 0)) {

--- a/network_diffusion/__init__.py
+++ b/network_diffusion/__init__.py
@@ -29,4 +29,4 @@ from network_diffusion.mln.mlnetwork import MultilayerNetwork
 from network_diffusion.simulator import Simulator
 from network_diffusion.tpn.tpnetwork import TemporalNetwork
 
-__version__ = "0.12.0a3"
+__version__ = "0.12.0a4"

--- a/network_diffusion/__init__.py
+++ b/network_diffusion/__init__.py
@@ -29,4 +29,4 @@ from network_diffusion.mln.mlnetwork import MultilayerNetwork
 from network_diffusion.simulator import Simulator
 from network_diffusion.tpn.tpnetwork import TemporalNetwork
 
-__version__ = "0.12.0a6"
+__version__ = "0.12.0"

--- a/network_diffusion/__init__.py
+++ b/network_diffusion/__init__.py
@@ -29,4 +29,4 @@ from network_diffusion.mln.mlnetwork import MultilayerNetwork
 from network_diffusion.simulator import Simulator
 from network_diffusion.tpn.tpnetwork import TemporalNetwork
 
-__version__ = "0.11.0"
+__version__ = "0.12.0a3"

--- a/network_diffusion/__init__.py
+++ b/network_diffusion/__init__.py
@@ -29,4 +29,4 @@ from network_diffusion.mln.mlnetwork import MultilayerNetwork
 from network_diffusion.simulator import Simulator
 from network_diffusion.tpn.tpnetwork import TemporalNetwork
 
-__version__ = "0.12.0a4"
+__version__ = "0.12.0a5"

--- a/network_diffusion/__init__.py
+++ b/network_diffusion/__init__.py
@@ -29,4 +29,4 @@ from network_diffusion.mln.mlnetwork import MultilayerNetwork
 from network_diffusion.simulator import Simulator
 from network_diffusion.tpn.tpnetwork import TemporalNetwork
 
-__version__ = "0.12.0a5"
+__version__ = "0.12.0a6"

--- a/requirements/develop.txt
+++ b/requirements/develop.txt
@@ -1,6 +1,7 @@
 coverage==7.2.7
 cryptography==41.0.3
 pre-commit==3.2.0
+pypandoc==1.11
 pytest==7.1.2
 scipy==1.11.1
 Sphinx==6.2.1

--- a/requirements/develop.txt
+++ b/requirements/develop.txt
@@ -1,9 +1,9 @@
 coverage==7.2.7
 cryptography==41.0.3
 pre-commit==3.2.0
-pypandoc==1.11
 pytest==7.1.2
 scipy==1.11.1
 Sphinx==6.2.1
 sphinx-book-theme==1.0.1
+twine==4.0.2
 wheel==0.38.4

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@
 
 from typing import List
 
-from pypandoc import convert_file
 from setuptools import Extension, find_packages, setup
 
 from network_diffusion import __version__
@@ -37,11 +36,8 @@ def parse_requirements() -> List[str]:
 
 def parse_readme() -> str:
     """Convert README to rst standard."""
-    try:
-        long_description = convert_file("README.md", "rst")
-    except (IOError, ImportError):
-        with open("README.md", encoding="utf-8") as file:
-            long_description = file.read()
+    with open("README.md", encoding="utf-8") as file:
+        long_description = file.read()
     return long_description
 
 
@@ -75,6 +71,7 @@ setup(
     ],
     description="Package to design and run diffusion phenomena in networks.",
     long_description=parse_readme(),
+    long_description_content_type="text/markdown",
     author="Michał Czuba, Piotr Bródka",
     author_email="michal.czuba@pwr.edu.pl, piotr.brodka@pwr.edu.pl",
     install_requires=parse_requirements(),

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@
 
 from typing import List
 
+from pypandoc import convert_file
 from setuptools import Extension, find_packages, setup
 
 from network_diffusion import __version__
@@ -29,11 +30,19 @@ from network_diffusion import __version__
 
 def parse_requirements() -> List[str]:
     """Parse requirements from the txt file."""
-    with open(
-        file="requirements/production.txt", encoding="utf-8", mode="r"
-    ) as file:
+    with open(file="requirements/production.txt", encoding="utf-8") as file:
         requirements = file.readlines()
     return requirements
+
+
+def parse_readme() -> str:
+    """Convert README to rst standard."""
+    try:
+        long_description = convert_file("README.md", "rst")
+    except (IOError, ImportError):
+        with open("README.md", encoding="utf-8") as file:
+            long_description = file.read()
+    return long_description
 
 
 setup(
@@ -65,7 +74,7 @@ setup(
         "temporal networks",
     ],
     description="Package to design and run diffusion phenomena in networks.",
-    long_description="Network Diffusion",  # TODO: fix the issue long_description_content_type` missing. defaulting
+    long_description=parse_readme(),
     author="Michał Czuba, Piotr Bródka",
     author_email="michal.czuba@pwr.edu.pl, piotr.brodka@pwr.edu.pl",
     install_requires=parse_requirements(),

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
         "temporal networks",
     ],
     description="Package to design and run diffusion phenomena in networks.",
-    long_description="Network Diffusion",
+    long_description="Network Diffusion",  # TODO: fix the issue long_description_content_type` missing. defaulting
     author="Michał Czuba, Piotr Bródka",
     author_email="michal.czuba@pwr.edu.pl, piotr.brodka@pwr.edu.pl",
     install_requires=parse_requirements(),

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
     install_requires=parse_requirements(),
     ext_modules=[
         Extension(
-            "network_diffusion.tpn.cogsnet_lib",
+            name="network_diffusion.tpn.cogsnet_lib",
             include_dirs=["c_modules"],
             sources=["c_modules/cogsnet_compute.c", "c_modules/cogsnet_lib.c"],
         )


### PR DESCRIPTION
I fixed CICD pipeline that was responsible for building the package. Since we added CogSNet that is written in C, this library ceased to be an OS-agnostic. Therefore, I had to modify the pipeline.

Here's what changed:
- library is configured to be built for macOS and Linux (i.e. "manylinux") targets
- landing page of library is modified and doesn't look like a...
- prior merging, you can test a pre-release version.

Known bugs:
- package cannot be built for Windows. That's because of usage `<unistd.h>` which is specific for Unix family (https://github.com/anty-filidor/network_diffusion/blob/28bf12d463ff45ec292f834527143303609ff3f0/c_modules/cogsnet_compute.c#L20)

For a quick lookup:
- new landing page GitHub: https://github.com/anty-filidor/network_diffusion/tree/fix--cicid-for-c-ports
- new landing page PyPI: https://pypi.org/project/network-diffusion/0.12.0a4/
- a proof that CICD works well: https://github.com/anty-filidor/network_diffusion/actions/runs/6130621098
- a pre-release version of the package with CogSNet: `pip install network-diffusion==0.12.0a4`